### PR TITLE
Fix extra opening brace causing syntax error in "Creating middleware"

### DIFF
--- a/docs/guides/creating-middleware/index.md
+++ b/docs/guides/creating-middleware/index.md
@@ -26,7 +26,7 @@ class CustomMiddleware extends AbstractMiddleware
         ObjectWrapper $object,
         PropertyMap $propertyMap,
         JsonMapperInterface $mapper
-    ): void {
+    ): void
     {
         // Custom logic goes here.
     }


### PR DESCRIPTION
The "Creating middleware" page's code example has an extra opening brace, causing code to break when copy-pasted.

https://jsonmapper.net/docs/guides/creating-middleware
